### PR TITLE
Update bindgen to version 0.69.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ links = "qrack_invoke"
 build = "src/build.rs"
 
 [build-dependencies]
-bindgen = "0.53.1"
+bindgen = "0.69.4"
 
 [lib]
 name = "qook"          # The name of the target.

--- a/src/build.rs
+++ b/src/build.rs
@@ -17,7 +17,7 @@ fn main() {
         .header("include/pinvoke_api.hpp")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         // Finish the builder and generate the bindings.A
         .generate()
         // Unwrap the Result and panic on failure.


### PR DESCRIPTION
The previous bindgen version (`0.53.1`) was vulnerable due to its dependency `shlex@^0.1` (all dependencies `shlex@<1.3.0` are vulnerable according to https://github.com/advisories/GHSA-r7qv-8r2h-pg27).

This commit updates the bindgen version to the last one published to date that has `shlex@^1` as a dependency, and so should not be vulnerable anymore.

Fixes #2 